### PR TITLE
Fix health check by not removing curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,7 @@ RUN set -ex \
  && curl -sSfLo /usr/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64" \
  && chmod 0755 \
       /usr/bin/dumb-init \
-      /usr/bin/gosu \
- && apk --no-cache del \
-      curl
+      /usr/bin/gosu
 
 VOLUME /config
 EXPOSE 8000 8001
@@ -25,3 +23,6 @@ EXPOSE 8000 8001
 ADD startup.sh /usr/bin/startup.sh
 
 ENTRYPOINT ["/usr/bin/startup.sh"]
+
+# healthcheck
+HEALTHCHECK CMD curl -sL --fail localhost:8000 || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,3 @@ EXPOSE 8000 8001
 ADD startup.sh /usr/bin/startup.sh
 
 ENTRYPOINT ["/usr/bin/startup.sh"]
-
-# healthcheck
-HEALTHCHECK CMD curl -sL --fail localhost:8000 || exit 1


### PR DESCRIPTION
I should have checked to ensure the container had `curl` first! Because it does not, this causes the healthcheck to fail :( Sorry for the bad pull request